### PR TITLE
Main_Widget: Add tooltips wo selection icons

### DIFF
--- a/mainWidget/main_widget.yaml
+++ b/mainWidget/main_widget.yaml
@@ -55,7 +55,7 @@ config:
       text-decoration: underline;
       text-underline-offset: 2px;
       font-weight: bold;
-    } 
+    }
 
     .unselected_menu_item {
       color: #8C8C8C;
@@ -64,29 +64,29 @@ config:
 
     .selected_bottom_navbar_item {
      color: white;
-     
+
      font-size: 12px;
      height: auto;
-     --f7-button-bg-color: transparent;  
+     --f7-button-bg-color: transparent;
      display: flex;
      flex-direction: column;
      align-items: center;
      padding-top: 1%;
      padding-bottom: 1%;
 
-    }  
+    }
 
     .unselected_bottom_navbar_item {
-     
+
      color: #8c8c8c;
      font-size: 12px;
      height: auto;
-     --f7-button-bg-color: transparent 
+     --f7-button-bg-color: transparent
           display: flex;
      flex-direction: column;
      padding-top: 2%;
      padding-bottom: 2%;
-    } 
+    }
 slots:
   default:
     - component: f7-block
@@ -470,6 +470,7 @@ slots:
                     icon-f7: shield_fill
                     iconBadge: =(Number(items.gDoorsOpen.state)+Number(items.gWindowsOpen.state)+Number(items.motionDetected.state))
                     text: Security
+                    tooltip: Security
                 - component: oh-link
                   config:
                     action: variable
@@ -482,6 +483,7 @@ slots:
                     class: '=(vars.objVar && (vars.objVar.selectThing=="Scenes")) ? "selected_bottom_navbar_item" : "unselected_bottom_navbar_item"'
                     icon-f7: rectangle_on_rectangle_angled
                     text: Scenes
+                    tooltip: Scenes
                 - component: oh-link
                   config:
                     action: variable
@@ -494,6 +496,7 @@ slots:
                     class: '=(vars.objVar && (vars.objVar.selectThing=="Weather")) ? "selected_bottom_navbar_item" : "unselected_bottom_navbar_item"'
                     iconMaterial: power
                     text: Appliances
+                    tooltip: Appliances
                 - component: oh-link
                   config:
                     action: variable
@@ -508,6 +511,7 @@ slots:
                     icon-f7: bolt_fill
                     iconBadge: ""
                     text: Energy
+                    tooltip: Energy
     - component: f7-block
       config:
         style:


### PR DESCRIPTION
First small functional change to add tooltips

This is useful for PC to see what the meating of the icons is.

Signed-off-by: Rosi2143 <Schrott.Micha@web.de>