### PR TITLE
FloorsAndRooms - Improvements

### DIFF
--- a/mainWidget/main_widget_FloorsAndRooms.yaml
+++ b/mainWidget/main_widget_FloorsAndRooms.yaml
@@ -59,7 +59,6 @@ slots:
                                 default:
                                   - component: oh-repeater
                                     config:
-                                      fetchMetadata: semantics
                                       filter: '(loop.lightPowerItem.type=="Switch") ? true : false'
                                       for: lightPowerItem
                                       fragment: true
@@ -100,7 +99,6 @@ slots:
                                 default:
                                   - component: oh-repeater
                                     config:
-                                      fetchMetadata: semantics
                                       filter: (loop.shutterItem.type == "Rollershutter") && (loop.shutterItem.tags).includes("Control")
                                       for: shutterItem
                                       fragment: true
@@ -110,7 +108,6 @@ slots:
                                       default:
                                         - component: oh-repeater
                                           config:
-                                            fetchMetadata: semantics
                                             filter: (loop.modeItem.type == "Switch") && (loop.modeItem.tags).includes("Control")
                                             for: modeItem
                                             fragment: true

--- a/mainWidget/main_widget_FloorsAndRooms.yaml
+++ b/mainWidget/main_widget_FloorsAndRooms.yaml
@@ -1,139 +1,219 @@
 uid: main_widget_FloorsAndRooms
-tags: []
+tags:
+  - improvements Nico_R
 props:
   parameterGroups: []
-timestamp: Nov 25, 2022, 2:04:15 PM
+timestamp: Feb 22, 2023, 4:29:23 PM
 component: f7-block
 config:
-  style:
-    flex: 1 1 auto
-    margin-bottom: -1em
-    margin-top: 1em
-    overflow: scroll
-  visible: '=vars.objVar ? (vars.objVar.selectSection=="SECTION0") ? false : true : false'
+  stylesheet: >
+    .invisible {
+      display: none;
+      /*position: absolute;*/
+      /*left: -999em;*/
+      /*opacity: 0.1;*/
+    }    
 slots:
   default:
-    - component: oh-repeater
-      config:
-        fetchMetadata: semantics,metadata,widgetOrder
-        filter: '(vars.objVar && vars.objVar.floor) ? loop.floorItem.name==vars.objVar.floor : (loop.floorItem.metadata) && (loop.floorItem.metadata.semantics.value).includes("Floor")'
-        for: floorItem
-        itemTags: ","
-        sourceType: itemsWithTags
+    - component: f7-block
       slots:
         default:
-          - component: oh-repeater
+          - component: f7-row
             config:
-              fetchMetadata: semantics,metadata,widgetOrder
-              filter: '(vars.objVar && vars.objVar.room) ? loop.roomItem.name==vars.objVar.room : (loop.roomItem.metadata) && ( (loop.roomItem.metadata.semantics.value).includes("Room") || (loop.roomItem.metadata.semantics.value).includes("Corridor") )'
-              for: roomItem
-              groupItem: =loop.floorItem.name
-              sourceType: itemsInGroup
+              class:
+                - justify-content-center
             slots:
               default:
                 - component: oh-repeater
                   config:
-                    fetchMetadata: semantics,metadata,listWidget,uiSemantics
-                    filter: loop.lightItem.metadata.semantics.config.hasLocation == loop.roomItem.name
-                    for: lightItem
-                    itemTags: Lightbulb
+                    fetchMetadata: semantics,widgetOrder
+                    filter: (loop.floors.metadata) && (loop.floors.metadata.semantics.value).includes("Floor")
+                    for: floors
+                    fragment: true
+                    itemTags: ","
                     sourceType: itemsWithTags
                   slots:
                     default:
                       - component: oh-repeater
                         config:
-                          fetchMetadata: semantics,metadata,listWidget,uiSemantics
-                          filter: '(loop.lightPowerItem.type=="Switch") ? true : false'
-                          for: lightPowerItem
-                          groupItem: =loop.lightItem.name
-                          sourceType: itemsInGroup
-                        slots:
-                          default:
-                            - component: widget:main_widget_Light_Card
-                              config:
-                                Title: "=loop.lightItem.metadata.uiSemantics ? loop.lightItem.metadata.uiSemantics.config.equipment + loop.lightItem.metadata.uiSemantics.config.preposition + loop.lightItem.metadata.uiSemantics.config.location : loop.lightItem.label"
-                                groupItem: =loop.lightItem.name
-                                powerItem: = loop.lightPowerItem.name
-                                visible: '=!vars.objVar ? false : !vars.objVar.selectThing ? true : (vars.objVar.selectThing=="Lights") ? true : false'
-                - component: oh-repeater
-                  config:
-                    fetchMetadata: semantics,metadata,uiSemantics
-                    filter: loop.equipmentItem.metadata.semantics.config.hasLocation == loop.roomItem.name
-                    for: equipmentItem
-                    itemTags: Blinds
-                    sourceType: itemsWithTags
-                  slots:
-                    default:
-                      - component: oh-repeater
-                        config:
-                          fetchMetadata: semantics,metadata,uiSemantics
-                          filter: '(loop.shutterItem.type=="Rollershutter") ? true : false'
-                          for: shutterItem
-                          groupItem: =loop.equipmentItem.name
+                          fetchMetadata: semantics
+                          filter: (loop.rooms.metadata) && ((loop.rooms.metadata.semantics.value).includes("Room")  || (loop.rooms.metadata.semantics.value).includes("Corridor"))
+                          for: rooms
+                          fragment: true
+                          groupItem: =loop.floors.name
                           sourceType: itemsInGroup
                         slots:
                           default:
                             - component: oh-repeater
                               config:
-                                fetchMetadata: semantics,metadata
-                                filter: loop.modeItem.type=="Switch"
-                                for: modeItem
-                                groupItem: =loop.equipmentItem.name
-                                sourceType: itemsInGroup
-                              slots:
-                                default:
-                                  - component: widget:main_widget_Rollershutter_Card
-                                    config:
-                                      groupItem: =loop.equipmentItem.name
-                                      RollerItem: =loop.shutterItem.name
-                                      RollerMode: = loop.modeItem.name
-                                      Title: "=loop.equipmentItem.metadata.uiSemantics ? loop.equipmentItem.metadata.uiSemantics.config.equipment + loop.equipmentItem.metadata.uiSemantics.config.preposition + loop.equipmentItem.metadata.uiSemantics.config.location : loop.equipmentItem.label"
-                                      visible: '=!vars.objVar ? false : !vars.objVar.selectThing ? false : (vars.objVar.selectThing=="Rollers") ? true : false'
-                - component: oh-repeater
-                  config:
-                    fetchMetadata: semantics,metadata,listWidget,uiSemantics
-                    filter: loop.radiatorItem.metadata.semantics.config.hasLocation == loop.roomItem.name
-                    for: radiatorItem
-                    itemTags: RadiatorControl
-                    sourceType: itemsWithTags
-                  slots:
-                    default:
-                      - component: widget:main_widget_RadiatorControl_Card
-                        config:
-                          Title: "=loop.radiatorItem.metadata.uiSemantics ? loop.radiatorItem.metadata.uiSemantics.config.equipment + loop.radiatorItem.metadata.uiSemantics.config.preposition + loop.radiatorItem.metadata.uiSemantics.config.location : loop.radiatorItem.label"
-                          groupItem: =loop.radiatorItem.name
-                          visible: '=!vars.objVar ? false : !vars.objVar.selectThing ? false : (vars.objVar.selectThing=="Climate") ? true : false'
-                - component: oh-repeater
-                  config:
-                    fetchMetadata: semantics,metadata,listWidget,uiSemantics
-                    filter: loop.hvacItem.metadata.semantics.config.hasLocation == loop.roomItem.name
-                    for: hvacItem
-                    itemTags: HVAC
-                    sourceType: itemsWithTags
-                  slots:
-                    default:
-                      - component: oh-repeater
-                        config:
-                          fetchMetadata: semantics,metadata,listWidget,uiSemantics
-                          filter: '((loop.hvacPowerItem.groupNames.indexOf(loop.hvacItem.name) >= 0) && (loop.hvacPowerItem.type=="Switch")) ? true : false'
-                          for: hvacPowerItem
-                          itemTags: Control,Power
-                          sourceType: itemsWithTags
-                        slots:
-                          default:
-                            - component: oh-repeater
-                              config:
-                                fetchMetadata: semantics,metadata,listWidget
-                                filter: '((loop.hvacModeItem.groupNames.indexOf(loop.hvacItem.name) >= 0) && (loop.hvacModeItem.type=="String")) ? true : false'
-                                for: hvacModeItem
-                                itemTags: Control,Temperature
+                                fetchMetadata: semantics,uiSemantics
+                                filter: (loop.lightItem.metadata.semantics.config) && (loop.lightItem.metadata.semantics.config.hasLocation) && (loop.lightItem.metadata.semantics.config.hasLocation == loop.rooms.name)
+                                for: lightItem
+                                fragment: true
+                                itemTags: Lightbulb
                                 sourceType: itemsWithTags
                               slots:
                                 default:
-                                  - component: widget:main_widget_HVAC_Card
+                                  - component: oh-repeater
                                     config:
-                                      Title: "=loop.hvacItem.metadata.uiSemantics ? loop.hvacItem.metadata.uiSemantics.config.equipment + loop.hvacItem.metadata.uiSemantics.config.preposition + loop.hvacItem.metadata.uiSemantics.config.location : loop.hvacItem.label"
-                                      groupItem: =loop.hvacItem.name
-                                      modeItem: =loop.hvacModeItem.name
-                                      powerItem: =loop.hvacPowerItem.name
-                                      visible: '=!vars.objVar ? false : !vars.objVar.selectThing ? false : (vars.objVar.selectThing=="Climate") ? true : false'
+                                      fetchMetadata: semantics
+                                      filter: '(loop.lightPowerItem.type=="Switch") ? true : false'
+                                      for: lightPowerItem
+                                      fragment: true
+                                      groupItem: =loop.lightItem.name
+                                      sourceType: itemsInGroup
+                                    slots:
+                                      default:
+                                        - component: f7-col
+                                          config:
+                                            class:
+                                              - '=((vars.objVar.room == loop.lightItem.metadata.semantics.config.hasLocation || (vars.objVar.selectSection == "SECTION2" && !vars.objVar.floor && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION2" && vars.objVar.floor == loop.rooms.metadata.semantics.config.isPartOf && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION1")) && (vars.objVar.selectThing == "Lights" || !vars.objVar.selectThing )) ? "visible" : "invisible"'
+                                            large: 50
+                                            medium: 50
+                                            small: 90
+                                            style:
+                                              overflow: hidden
+                                            width: 100
+                                            xlarge: 33
+                                            xsmall: 100
+                                          slots:
+                                            default:
+                                              - component: widget:main_widget_Light_Card
+                                                config:
+                                                  Title: "=loop.lightItem.metadata.uiSemantics ? loop.lightItem.metadata.uiSemantics.config.equipment + loop.lightItem.metadata.uiSemantics.config.preposition + loop.lightItem.metadata.uiSemantics.config.location : loop.lightItem.label"
+                                                  groupItem: =loop.lightItem.name
+                                                  groupItemLabel: =loop.lightItem.label
+                                                  groupItemLocation: =loop.rooms.label
+                                                  powerItem: = loop.lightPowerItem.name
+                            - component: oh-repeater
+                              config:
+                                fetchMetadata: semantics,metadata,listWidget
+                                filter: (loop.equipmentItem.metadata.semantics.config) && (loop.equipmentItem.metadata.semantics.config.hasLocation) && (loop.equipmentItem.metadata.semantics.config.hasLocation == loop.rooms.name)
+                                for: equipmentItem
+                                fragment: true
+                                itemTags: Blinds
+                                sourceType: itemsWithTags
+                              slots:
+                                default:
+                                  - component: oh-repeater
+                                    config:
+                                      fetchMetadata: semantics,metadata,uiSemantics
+                                      filter: (loop.shutterItem.type == "Rollershutter") && (loop.shutterItem.tags).includes("Control")
+                                      for: shutterItem
+                                      fragment: true
+                                      groupItem: =loop.equipmentItem.name
+                                      sourceType: itemsInGroup
+                                    slots:
+                                      default:
+                                        - component: oh-repeater
+                                          config:
+                                            fetchMetadata: semantics,metadata
+                                            filter: (loop.modeItem.type == "Switch") && (loop.modeItem.tags).includes("Control")
+                                            for: modeItem
+                                            fragment: true
+                                            groupItem: =loop.equipmentItem.name
+                                            sourceType: itemsInGroup
+                                          slots:
+                                            default:
+                                              - component: f7-col
+                                                config:
+                                                  class:
+                                                    - '=((vars.objVar.room == loop.equipmentItem.metadata.semantics.config.hasLocation || (vars.objVar.selectSection == "SECTION2" && !vars.objVar.floor && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION2" && vars.objVar.floor == loop.rooms.metadata.semantics.config.isPartOf && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION1")) && (vars.objVar.selectThing == "Rollers" || !vars.objVar.selectThing )) ? "visible" : "invisible"'
+                                                  large: 50
+                                                  medium: 50
+                                                  small: 90
+                                                  style:
+                                                    overflow: hidden
+                                                  width: 100
+                                                  xlarge: 33
+                                                  xsmall: 100
+                                                slots:
+                                                  default:
+                                                    - component: widget:main_widget_Rollershutter_Card
+                                                      config:
+                                                        RollerItem: =loop.shutterItem.name
+                                                        RollerMode: = loop.modeItem.name
+                                                        Title: "=loop.equipmentItem.metadata.uiSemantics ? loop.equipmentItem.metadata.uiSemantics.config.equipment + loop.equipmentItem.metadata.uiSemantics.config.preposition + loop.equipmentItem.metadata.uiSemantics.config.location : loop.equipmentItem.label"
+                                                        groupItem: =loop.equipmentItem.name
+                                                        groupItemLabel: =loop.equipmentItem.label
+                                                        groupItemLocation: =loop.rooms.label
+                            - component: oh-repeater
+                              config:
+                                fetchMetadata: semantics,metadata,listWidget,uiSemantics
+                                filter: loop.radiatorItem.metadata.semantics.config.hasLocation == loop.rooms.name
+                                for: radiatorItem
+                                fragment: true
+                                itemTags: RadiatorControl
+                                sourceType: itemsWithTags
+                              slots:
+                                default:
+                                  - component: f7-col
+                                    config:
+                                      class:
+                                        - '=((vars.objVar.room == loop.radiatorItem.metadata.semantics.config.hasLocation || (vars.objVar.selectSection == "SECTION2" && !vars.objVar.floor && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION2" && vars.objVar.floor == loop.rooms.metadata.semantics.config.isPartOf && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION1")) && (vars.objVar.selectThing == "Climate" || !vars.objVar.selectThing )) ? "visible" : "invisible"'
+                                      large: 50
+                                      medium: 50
+                                      small: 90
+                                      style:
+                                        overflow: hidden
+                                      width: 100
+                                      xlarge: 33
+                                      xsmall: 100
+                                    slots:
+                                      default:
+                                        - component: widget:main_widget_RadiatorControl_Card_Dev
+                                          config:
+                                            Title: "=loop.radiatorItem.metadata.uiSemantics ? loop.radiatorItem.metadata.uiSemantics.config.equipment + loop.radiatorItem.metadata.uiSemantics.config.preposition + loop.radiatorItem.metadata.uiSemantics.config.location : loop.radiatorItem.label"
+                                            groupItem: =loop.radiatorItem.name
+                                            groupItemLabel: =loop.radiatorItem.label
+                                            groupItemLocation: =loop.rooms.label
+                            - component: oh-repeater
+                              config:
+                                fetchMetadata: semantics,metadata,listWidget,uiSemantics
+                                filter: loop.hvacItem.metadata.semantics.config.hasLocation == loop.rooms.name
+                                for: hvacItem
+                                fragment: true
+                                itemTags: HVAC
+                                sourceType: itemsWithTags
+                              slots:
+                                default:
+                                  - component: oh-repeater
+                                    config:
+                                      fetchMetadata: semantics,metadata,listWidget,uiSemantics
+                                      filter: '((loop.hvacPowerItem.groupNames.indexOf(loop.hvacItem.name) >= 0) && (loop.hvacPowerItem.type=="Switch")) ? true : false'
+                                      for: hvacPowerItem
+                                      fragment: true
+                                      itemTags: Control,Power
+                                      sourceType: itemsWithTags
+                                    slots:
+                                      default:
+                                        - component: oh-repeater
+                                          config:
+                                            fetchMetadata: semantics,metadata,listWidget
+                                            filter: '((loop.hvacModeItem.groupNames.indexOf(loop.hvacItem.name) >= 0) && (loop.hvacModeItem.type=="String")) ? true : false'
+                                            for: hvacModeItem
+                                            fragment: true
+                                            itemTags: Control,Temperature
+                                            sourceType: itemsWithTags
+                                          slots:
+                                            default:
+                                              - component: f7-col
+                                                config:
+                                                  class:
+                                                    - '=((vars.objVar.room == loop.hvacItem.metadata.semantics.config.hasLocation || (vars.objVar.selectSection == "SECTION2" && !vars.objVar.floor && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION2" && vars.objVar.floor == loop.rooms.metadata.semantics.config.isPartOf && !vars.objVar.room) || (vars.objVar.selectSection == "SECTION1")) && (vars.objVar.selectThing == "Climate" || !vars.objVar.selectThing )) ? "visible" : "invisible"'
+                                                  large: 50
+                                                  medium: 50
+                                                  small: 90
+                                                  style:
+                                                    overflow: hidden
+                                                  width: 100
+                                                  xlarge: 33
+                                                  xsmall: 100
+                                                slots:
+                                                  default:
+                                                    - component: widget:main_widget_HVAC_Card
+                                                      config:
+                                                        Title: "=loop.hvacItem.metadata.uiSemantics ? loop.hvacItem.metadata.uiSemantics.config.equipment + loop.hvacItem.metadata.uiSemantics.config.preposition + loop.hvacItem.metadata.uiSemantics.config.location : loop.hvacItem.label"
+                                                        groupItem: =loop.hvacItem.name
+                                                        modeItem: =loop.hvacModeItem.name
+                                                        powerItem: =loop.hvacPowerItem.name

--- a/mainWidget/main_widget_FloorsAndRooms.yaml
+++ b/mainWidget/main_widget_FloorsAndRooms.yaml
@@ -3,7 +3,7 @@ tags:
   - improvements Nico_R
 props:
   parameterGroups: []
-timestamp: Feb 22, 2023, 4:29:23 PM
+timestamp: Feb 26, 2023, 8:13:47 PM
 component: f7-block
 config:
   stylesheet: >
@@ -18,7 +18,7 @@ slots:
     - component: f7-block
       config:
         class:
-          - '=vars.objVar ? (vars.objVar.selectSection=="SECTION0") ? "" : "" : "invisible"'    
+          - '=vars.objVar ? (vars.objVar.selectSection=="SECTION0") ? "" : "" : "invisible"'
       slots:
         default:
           - component: f7-row
@@ -90,7 +90,7 @@ slots:
                                                   powerItem: = loop.lightPowerItem.name
                             - component: oh-repeater
                               config:
-                                fetchMetadata: semantics,metadata,listWidget
+                                fetchMetadata: semantics,uiSemantics
                                 filter: (loop.equipmentItem.metadata.semantics.config) && (loop.equipmentItem.metadata.semantics.config.hasLocation) && (loop.equipmentItem.metadata.semantics.config.hasLocation == loop.rooms.name)
                                 for: equipmentItem
                                 fragment: true
@@ -100,7 +100,7 @@ slots:
                                 default:
                                   - component: oh-repeater
                                     config:
-                                      fetchMetadata: semantics,metadata,uiSemantics
+                                      fetchMetadata: semantics
                                       filter: (loop.shutterItem.type == "Rollershutter") && (loop.shutterItem.tags).includes("Control")
                                       for: shutterItem
                                       fragment: true
@@ -110,7 +110,7 @@ slots:
                                       default:
                                         - component: oh-repeater
                                           config:
-                                            fetchMetadata: semantics,metadata
+                                            fetchMetadata: semantics
                                             filter: (loop.modeItem.type == "Switch") && (loop.modeItem.tags).includes("Control")
                                             for: modeItem
                                             fragment: true
@@ -142,7 +142,7 @@ slots:
                                                         groupItemLocation: =loop.rooms.label
                             - component: oh-repeater
                               config:
-                                fetchMetadata: semantics,metadata,listWidget,uiSemantics
+                                fetchMetadata: semantics,uiSemantics
                                 filter: loop.radiatorItem.metadata.semantics.config.hasLocation == loop.rooms.name
                                 for: radiatorItem
                                 fragment: true
@@ -172,7 +172,7 @@ slots:
                                             groupItemLocation: =loop.rooms.label
                             - component: oh-repeater
                               config:
-                                fetchMetadata: semantics,metadata,listWidget,uiSemantics
+                                fetchMetadata: semantics,uiSemantics
                                 filter: loop.hvacItem.metadata.semantics.config.hasLocation == loop.rooms.name
                                 for: hvacItem
                                 fragment: true
@@ -182,7 +182,7 @@ slots:
                                 default:
                                   - component: oh-repeater
                                     config:
-                                      fetchMetadata: semantics,metadata,listWidget,uiSemantics
+                                      fetchMetadata: semantics
                                       filter: '((loop.hvacPowerItem.groupNames.indexOf(loop.hvacItem.name) >= 0) && (loop.hvacPowerItem.type=="Switch")) ? true : false'
                                       for: hvacPowerItem
                                       fragment: true
@@ -192,7 +192,7 @@ slots:
                                       default:
                                         - component: oh-repeater
                                           config:
-                                            fetchMetadata: semantics,metadata,listWidget
+                                            fetchMetadata: semantics
                                             filter: '((loop.hvacModeItem.groupNames.indexOf(loop.hvacItem.name) >= 0) && (loop.hvacModeItem.type=="String")) ? true : false'
                                             for: hvacModeItem
                                             fragment: true

--- a/mainWidget/main_widget_FloorsAndRooms.yaml
+++ b/mainWidget/main_widget_FloorsAndRooms.yaml
@@ -16,6 +16,9 @@ config:
 slots:
   default:
     - component: f7-block
+      config:
+        class:
+          - '=vars.objVar ? (vars.objVar.selectSection=="SECTION0") ? "" : "" : "invisible"'    
       slots:
         default:
           - component: f7-row
@@ -161,7 +164,7 @@ slots:
                                       xsmall: 100
                                     slots:
                                       default:
-                                        - component: widget:main_widget_RadiatorControl_Card_Dev
+                                        - component: widget:main_widget_RadiatorControl_Card
                                           config:
                                             Title: "=loop.radiatorItem.metadata.uiSemantics ? loop.radiatorItem.metadata.uiSemantics.config.equipment + loop.radiatorItem.metadata.uiSemantics.config.preposition + loop.radiatorItem.metadata.uiSemantics.config.location : loop.radiatorItem.label"
                                             groupItem: =loop.radiatorItem.name


### PR DESCRIPTION
- Improved the general structure so that each widget is contained in a col. This ensures a responsive design.

- New items do not necessarily have to have a "config" parameter. Therefore the function does not filter out items with missing location. -> (loop.lightItem.metadata.semantics.config) && (loop.lightItem.metadata.semantics.config.hasLocation)

- Extension of the properties for Lights. Preparation for widgets, since data is already available from Repeater. -> - groupItemName: =loop.lightItem.label
-> - groupItemLocation: =loop.rooms.label

- Extension of the properties for Blinds. Preparation for widgets, since data is already available from Repeater. -> - groupItemLabel: =loop.equipmentItem.label
-> - groupItemLocation: =loop.rooms.label

- Extension of the properties for Radiators. Preparation for widgets, since data is already available from Repeater. -> - groupItemLabel: =loop.radiatorItem.label
-> - groupItemLocation: =loop.rooms.label

- Filter for blinds extended. There are users who have HmIP in use and have to use proxy items. These are then not tagged but included in the group.

fixes #30 also

Backwards compatibility with existing widgets checked.
@hmerk Please check in your system. There might still be a few errors. ;-)

Signed-off-by: Nico Reichelt [nico.reichelt@gmail.com](mailto:nico.reichelt@gmail.com)